### PR TITLE
Set context accordingly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ TODO
 浏览器更迭，这些坑可能在不久的将来会成为历史，暂且统一列在这里。
 
 
-### .hasAttr('id')
+### `.hasAttr('id')`
 
 在 IE 6 和 7 里执行 `.getAttribute('id')` 返回的会是一个空字符串，而不是规范的 null，
 会导致 yen.fn.hasAttr 所采用的兼容方式判断失败，详见 #5。
@@ -74,12 +74,12 @@ TODO
 @luckydrq 是第一个踩到这个坑的人。
 
 
-### .css('margin')
+### `.css('margin')`
 
 在 Firefox 与 Safari 5 里执行 `.css('margin')` 并不会返回缩写的 margin 值，而是返回空。
 
 
-### .position()
+### `.position()`
 
 [jQuery.fn.position()][jQuery#position] 返回的 `top` 与 `left` 会去掉节点的
 marginTop 和 marginLeft，而 Element#offsetLeft 和 Element#offsetTop 是会把节点的
@@ -95,6 +95,19 @@ return {
 
 不过，这个返回值[在 IE[67] 里是有问题的][cssom#offsetLeft]，会无视 `position: relative`
 的父节点。
+
+
+### IE8 里的 `.querySelectorAll()`
+
+IE8 里的 `.querySelectorAll()` 功能有所残缺，仅支持 [CSS 2.1][css-2.1] 标准中所列的
+选择器，部分支持 [CSS 3][css-3] 标准里的选择器。
+
+目前踩到的有：
+
+```js
+document.querySelectorAll('#fixture li:last-child')     // 参数无效
+document.getElementById('fixture').querySelectorAll('li:last-child')    // 没问题
+```
 
 
 ### 有关 `.each()` and `.map()`
@@ -182,3 +195,5 @@ $ npm test
 [oceanifier]: https://github.com/erzu/oceanifier
 [jQuery#position]: http://api.jquery.com/position/
 [1]: http://cyj.me/f2e/2015/05/25/yen/
+[css-2.1]: http://caniuse.com/#feat=css-sel2
+[css-3]: http://caniuse.com/#feat=css-sel3

--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,48 @@ return {
 的父节点。
 
 
+### 有关 `.each()` and `.map()`
+
+在 jQuery 里，`.each()` 和 `.map()` 在调用传入的回调函数时，会动态改变这个函数的 this，
+变为当前迭代的节点：
+
+```js
+$('div').each(function(index, el) {
+  expect(this === el).to.be(true)
+})
+
+$('div').map(function(index, el) {
+  expect(this === el).to.be(true)
+})
+```
+
+在 yen 里，`.each()` 和 `.map()` 的行为和 `Array.prototype` 上的一致（其实就是直接用了
+数组原型链上的这两个方法）：
+
+```js
+$('div').each(function(el, index) {
+  expect(this === window).to.be(true)
+})
+
+$('div').map(function(el, index) {
+  expect(this === window).to.be(true)
+})
+
+// 还有 .forEach()，和 .each() 的区别是 .forEach 没有返回值
+$('div').forEach(function(el, index) {
+  expect(this === window).to.be(true)
+})
+```
+
+总结一下，yen 里的 `.each()` 和 `.map()` 和 jQuery 的区别在于：
+
+1. jQuery 是 `function(index, el) {}`，而 yen 则是 `function(el, index) {}`
+2. 不会动态绑定 `this`，和 `Array.prototype` 上的一样，默认指向全局，但可以传入第二个
+   参数指定 `context`。
+
+但是我相信你会用得更加顺手。
+
+
 ## Tests - 测试
 
 我们使用 [oceanifier][oceanifier] 运行 HTTP 服务，默认端口 5000。

--- a/test/test.yen.js
+++ b/test/test.yen.js
@@ -342,7 +342,9 @@ describe('yen', function() {
     it('.prev', function() {
       expect($('#fixture .foo').prev().length).to.be(0)
       expect($('#fixture .bar').prev().hasClass('foo')).to.be(true)
-      expect($('#fixture li:last-child').prev().length).to.be(2)
+      // IE8 does has got `document.querySelectorAll` but will yield error on
+      // `document.querySelectorAll('#fixture li:last-child')`.
+      expect($('#fixture').find('li:last-child').prev().length).to.be(2)
     })
   })
 

--- a/test/test.yen.js
+++ b/test/test.yen.js
@@ -76,6 +76,8 @@ describe('yen', function() {
 
     it('.hasClass', function() {
       expect($('.entry').last().hasClass('entry-last')).to.be(true)
+      expect($('.entry').hasClass('entry-last')).to.be(false)
+      expect($().hasClass('foo')).to.be(false)
     })
 
     it('.addClass', function() {
@@ -203,7 +205,7 @@ describe('yen', function() {
       expect($('.entry-current').length).to.be(1)
     })
 
-    it('can descendant selector', function() {
+    it('can query descendant selector', function() {
       expect($('ul .entry').length).to.be(5)
       expect($('#ul .entry-current').length).to.be(1)
       expect($('#ul .a').length).to.be(1)
@@ -215,21 +217,21 @@ describe('yen', function() {
       expect($('html #ul [attr=""]').length).to.be(1)
     })
 
-    it('can combine selector', function() {
+    it('can query combine selector', function() {
       expect($('ul a.b[c=d]#e.f[g]').length).to.be(1)
     })
 
-    it('can child selector', function() {
+    it('can query child selector', function() {
       expect($('ul>li', $('#ul')[0]).length).to.be(5)
       expect($('ul > li > a', $('#ul')[0]).length).to.be(2)
     })
 
-    it('can pseudo-class selector', function() {
+    it('can query pseudo-class selector', function() {
       expect($('ul li:first-child', $('#ul')[0]).length).to.be(1)
       expect($('ul :first-child', $('#ul')[0]).length).to.be(3)
     })
 
-    it('can comma-separated selector', function() {
+    it('can query comma-separated selector', function() {
       expect($('ul,li,#e', $('#ul')[0]).length).to.be(6)
     })
 
@@ -334,11 +336,13 @@ describe('yen', function() {
     it('.next', function() {
       expect($('#fixture .egg').next().length).to.be(0)
       expect($('#fixture .foo').next().hasClass('bar')).to.be(true)
+      expect($('#fixture li:first-child').next().length).to.be(2)
     })
 
     it('.prev', function() {
       expect($('#fixture .foo').prev().length).to.be(0)
       expect($('#fixture .bar').prev().hasClass('foo')).to.be(true)
+      expect($('#fixture li:last-child').prev().length).to.be(2)
     })
   })
 
@@ -440,6 +444,22 @@ describe('yen', function() {
       expect($(a)[0]).to.equal(document)
       expect($(a)).to.not.equal(a)    // should return a clone
     })
+
+    it('accept HTMLCollection', function() {
+      var collection = document.getElementsByTagName('script')
+
+      expect($(collection).length).to.equal(collection.length)
+      if (document.scripts) {
+        expect($(document.scripts).length).to.equal(collection.length)
+      }
+    })
+
+    it('accept NodeList', function() {
+      if (document.querySelectorAll) {
+        var collection = document.querySelectorAll('script')
+        expect($(collection).length).to.equal(collection.length)
+      }
+    })
   })
 
   describe('iframe', function() {
@@ -486,6 +506,17 @@ describe('yen', function() {
       expect($('#title', inner).length).to.be(1)
       expect($('#title', outer)[0].nodeName.toLowerCase()).to.be('h1')
       expect($('#title', inner)[0].nodeName.toLowerCase()).to.be('h2')
+    })
+
+    it('can construct with elements within iframe', function() {
+      var el = $('#title', contentDocument)[0]
+
+      expect($(el).context).to.equal(el)
+      expect($(el).closest('div').is('.inner')).to.be(true)
+
+      var els = $(contentDocument.getElementsByTagName('div'))
+      expect(els.length).to.equal(1)
+      expect(els.context).to.equal(els)
     })
   })
 })


### PR DESCRIPTION
之前有个问题，如果实例化的时候直接传入节点，而这个节点是 iframe 里的时，后续的 `.parent()`、`.is()` 方法，在没有原生方法支持的时候都会出错（也就是 IE6-8）。