### PR TITLE
Fix: enhanced dimensional methods to be more compliant with jQuery

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "semi": [2, "never"],
     "strict": [2, "global"],
     "no-underscore-dangle": 0,
-    "no-use-before-define": [2, "nofunc"]
+    "no-use-before-define": [2, "nofunc"],
+    "no-undef": 2
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .DS_Store
 *.log
+tmp

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "ocean serve",
-    "test": "totoro --runner=http://`oceanify ip`:5000/test/runner.html"
+    "test": "totoro --runner=http://`ocean ip`:5000/test/runner.html"
   },
   "license": "MIT"
 }

--- a/test/runner.html
+++ b/test/runner.html
@@ -9,7 +9,6 @@
   <body>
     <div id="mocha"></div>
     <div id="fixture" style="display:none"></div>
-    <img src="https://img.alicdn.com/tps/TB1vy9CLVXXXXcvXFXXXXXXXXXX-120-60.png" alt="test image" id="img" style="display:none">
     <script src="/node_modules/mocha/mocha.js"></script>
     <!--[if lte IE 9]><!-->
     <script src="http://amo.alicdn.com/L1/377/10010/assets/es5-7dfe7fb63d161c704e2f35874957b921.js"></script>

--- a/test/runner.html
+++ b/test/runner.html
@@ -9,6 +9,7 @@
   <body>
     <div id="mocha"></div>
     <div id="fixture" style="display:none"></div>
+    <img src="https://img.alicdn.com/tps/TB1vy9CLVXXXXcvXFXXXXXXXXXX-120-60.png" alt="test image" id="img" style="display:none">
     <script src="/node_modules/mocha/mocha.js"></script>
     <!--[if lte IE 9]><!-->
     <script src="http://amo.alicdn.com/L1/377/10010/assets/es5-7dfe7fb63d161c704e2f35874957b921.js"></script>

--- a/test/test.yen.js
+++ b/test/test.yen.js
@@ -8,76 +8,96 @@ var heredoc = require('heredoc').strip
 describe('yen', function() {
 
   describe('dimension', function() {
-    before(function() {
-      $('#fixture').css({
+    before(function(done) {
+      $('#fixture').html(heredoc(function() {/*
+        <div class="rect"></div>
+        <div class="rect-hidden" style="display:none"></div>
+        <img src="https://img.alicdn.com/tps/TB1vy9CLVXXXXcvXFXXXXXXXXXX-120-60.png" alt="test image" class="img">
+        <img src="https://img.alicdn.com/tps/TB1vy9CLVXXXXcvXFXXXXXXXXXX-120-60.png" alt="test image" class="img-hidden" style="display:none">
+      */}))
+
+      $('#fixture div').css({
         width: '100px',
         height: '50px',
         padding: '10px 20px',
         border: '5px solid #000',
         margin: '10px 5px'
       })
+
+      $('#fixture').show()
+      $('#fixture img').on('load', function() {
+        done()
+      })
+    })
+
+    after(function() {
+      $('#fixture').hide()
     })
 
     it('.height', function() {
-      expect($('#fixture').height()).to.equal(50)
+      expect($('#fixture .rect').height()).to.equal(50)
+      expect($('#fixture .rect-hidden').height()).to.equal(50)
+      expect($('#fixture .img').height()).to.equal(60)
+      expect($('#fixture .img-hidden').height()).to.equal(60)
       expect($().height()).to.be(null)
     })
 
     it('.innerHeight', function() {
-      expect($('#fixture').innerHeight()).to.equal(70)
+      expect($('#fixture .rect').innerHeight()).to.equal(70)
+      expect($('#fixture .rect-hidden').innerHeight()).to.equal(70)
+      expect($('#fixture .img').innerHeight()).to.equal(60)
+      expect($('#fixture .img-hidden').innerHeight()).to.equal(60)
       expect($().innerHeight()).to.be(null)
     })
 
     it('.innerWidth', function() {
-      expect($('#fixture').innerWidth()).to.equal(140)
+      expect($('#fixture .rect').innerWidth()).to.equal(140)
+      expect($('#fixture .rect-hidden').innerWidth()).to.equal(140)
+      expect($('#fixture .img').innerWidth()).to.equal(120)
+      expect($('#fixture .img-hidden').innerWidth()).to.equal(120)
       expect($().innerWidth()).to.be(null)
     })
 
     it('.offset', function() {
       expect($().offset()).to.be(undefined)
 
-      var offset = $('#fixture').offset()
+      var offset = $('#fixture .rect').offset()
       expect(offset.left).to.be.a('number')
       expect(offset.top).to.be.a('number')
     })
 
     it('.outerHeight', function() {
-      expect($('#fixture').outerHeight()).to.equal(80)
-      expect($('#fixture').outerHeight(true)).to.equal(100)
+      expect($('#fixture .rect').outerHeight()).to.equal(80)
+      expect($('#fixture .rect').outerHeight(true)).to.equal(100)
+      expect($('#fixture .rect-hidden').outerHeight()).to.equal(80)
+      expect($('#fixture .rect-hidden').outerHeight(true)).to.equal(100)
+      expect($('#fixture .img').outerHeight()).to.equal(60)
+      expect($('#fixture .img').outerHeight(true)).to.equal(60)
+      expect($('#fixture .img-hidden').outerHeight()).to.equal(60)
+      expect($('#fixture .img-hidden').outerHeight(true)).to.equal(60)
       expect($().outerHeight()).to.be(null)
     })
 
     it('.outerWidth', function() {
-      expect($('#fixture').outerWidth()).to.equal(150)
-      expect($('#fixture').outerWidth(true)).to.equal(160)
+      expect($('#fixture .rect').outerWidth()).to.equal(150)
+      expect($('#fixture .rect').outerWidth(true)).to.equal(160)
+      expect($('#fixture .rect-hidden').outerWidth()).to.equal(150)
+      expect($('#fixture .rect-hidden').outerWidth(true)).to.equal(160)
+      expect($('#fixture .img').outerWidth()).to.equal(120)
+      expect($('#fixture .img').outerWidth(true)).to.equal(120)
+      expect($('#fixture .img-hidden').outerHeight()).to.equal(60)
+      expect($('#fixture .img-hidden').outerHeight(true)).to.equal(60)
+
       expect($().outerWidth()).to.be(null)
     })
 
     it('.width', function() {
-      expect($('#fixture').width()).to.equal(100)
+      expect($('#fixture .rect').width()).to.equal(100)
+      expect($('#fixture .rect-hidden').width()).to.equal(100)
+      expect($('#fixture .img').width()).to.equal(120)
+      expect($('#fixture .img-hidden').width()).to.equal(120)
       expect($().width()).to.be(null)
     })
-
-    it('img .height', function() {
-      expect($('#img').height()).to.equal(60)
-      expect($().height()).to.be(null)
-    })
-
-    it('img .innerHeight', function() {
-      expect($('#img').innerHeight()).to.equal(60)
-      expect($().innerHeight()).to.be(null)
-    })
-
-    it('img .width', function() {
-      expect($('#img').width()).to.equal(120)
-      expect($().width()).to.be(null)
-    })
-
-    it('img .innerWidth', function() {
-      expect($('#img').innerWidth()).to.equal(120)
-      expect($().innerWidth()).to.be(null)
-    })
-
   })
 
   describe('manipulation', function() {
@@ -527,8 +547,8 @@ describe('yen', function() {
             </div>
           </body>
         </html>
-      */})
-      )
+      */}))
+      contentDocument.close()
     })
 
     it('can select iFrame window', function() {

--- a/test/test.yen.js
+++ b/test/test.yen.js
@@ -57,6 +57,27 @@ describe('yen', function() {
       expect($('#fixture').width()).to.equal(100)
       expect($().width()).to.be(null)
     })
+
+    it('img .height', function() {
+      expect($('#img').height()).to.equal(60)
+      expect($().height()).to.be(null)
+    })
+
+    it('img .innerHeight', function() {
+      expect($('#img').innerHeight()).to.equal(60)
+      expect($().innerHeight()).to.be(null)
+    })
+
+    it('img .width', function() {
+      expect($('#img').width()).to.equal(120)
+      expect($().width()).to.be(null)
+    })
+
+    it('img .innerWidth', function() {
+      expect($('#img').innerWidth()).to.equal(120)
+      expect($().innerWidth()).to.be(null)
+    })
+
   })
 
   describe('manipulation', function() {


### PR DESCRIPTION
```js
.height()
.innerHeight()
.innerWidth()
.outerHeight()
.outerWidth()
.width()
```

The changes are:

1. will return actual width and height even if the element is `display: none`. but still will just return 0 if the element is within some container that is hidden. same as jQuery.
2. will return correct value if the element is `box-sizing: border-box`.

The `.css` method is now enhanced too. It will find corresponding vendor prefixed property names now.